### PR TITLE
Feat: http.ping

### DIFF
--- a/MelonJs.JavaScript/Bindings/Constructors/PingResponse.js
+++ b/MelonJs.JavaScript/Bindings/Constructors/PingResponse.js
@@ -1,0 +1,8 @@
+﻿class PingResponse {
+    constructor(results, max, min, average) {
+        this.results = results;
+        this.max = max;
+        this.min = min;
+        this.average = average;
+    }
+}

--- a/MelonJs.JavaScript/Bindings/Tools/http.js
+++ b/MelonJs.JavaScript/Bindings/Tools/http.js
@@ -7,23 +7,23 @@
 
         //Calling "Response.js" binding constructor
         return new Response(
-            rawResult.Body,
-            rawResult.Headers,
-            rawResult.Latency,
-            rawResult.StatusCode,
-            rawResult.Ok
+            rawResult.Body ?? "",
+            rawResult.Headers ?? {},
+            rawResult.Latency ?? 0,
+            rawResult.StatusCode ?? 599,
+            rawResult.Ok ?? false
         );
     },
 
-    ping: (target, times) => {
+    ping: (target, times = 1) => {
         const rawResult = melon_internal_ping_request(target, times);
 
         //Calling "PingResponse.js" binding constructor
         return new PingResponse(
-            rawResult.Results,
-            rawResult.MaxLatency,
-            rawResult.MinLatency,
-            rawResult.AverageLatency
+            rawResult.Results ?? [],
+            rawResult.MaxLatency ?? 0,
+            rawResult.MinLatency ?? 0,
+            rawResult.AverageLatency ?? 0
         );
     }
 }

--- a/MelonJs.JavaScript/Bindings/Tools/http.js
+++ b/MelonJs.JavaScript/Bindings/Tools/http.js
@@ -5,12 +5,25 @@
 
         const rawResult = melon_internal_fetch_request(target, method, body, headers);
 
+        //Calling "Response.js" binding constructor
         return new Response(
-            rawResult.body,
-            rawResult.headers,
-            rawResult.latency,
-            rawResult.statusCode,
-            rawResult.ok
+            rawResult.Body,
+            rawResult.Headers,
+            rawResult.Latency,
+            rawResult.StatusCode,
+            rawResult.Ok
+        );
+    },
+
+    ping: (target, times) => {
+        const rawResult = melon_internal_ping_request(target, times);
+
+        //Calling "PingResponse.js" binding constructor
+        return new PingResponse(
+            rawResult.Results,
+            rawResult.MaxLatency,
+            rawResult.MinLatency,
+            rawResult.AverageLatency
         );
     }
 }

--- a/MelonJs.JavaScript/Extensions/EngineExtensions.cs
+++ b/MelonJs.JavaScript/Extensions/EngineExtensions.cs
@@ -51,6 +51,7 @@ namespace MelonJs.JavaScript.Extensions
 
             engine.Execute(BindingReader.Get("Tools/http"));
             engine.Execute(BindingReader.Get("Constructors/Response"));
+            engine.Execute(BindingReader.Get("Constructors/PingResponse"));
         }
 
         /// <summary>

--- a/MelonJs.JavaScript/Extensions/EngineExtensions.cs
+++ b/MelonJs.JavaScript/Extensions/EngineExtensions.cs
@@ -46,6 +46,9 @@ namespace MelonJs.JavaScript.Extensions
             engine.SetValue("melon_internal_fetch_request", 
                 new Func<string, string, string, string, MelonHttpResponse>(MelonHttp.Request));
 
+            engine.SetValue("melon_internal_ping_request", 
+                new Func<string, uint, MelonPingReply>(MelonHttp.Ping));
+
             engine.Execute(BindingReader.Get("Tools/http"));
             engine.Execute(BindingReader.Get("Constructors/Response"));
         }

--- a/MelonJs.JavaScript/MelonJs.JavaScript.csproj
+++ b/MelonJs.JavaScript/MelonJs.JavaScript.csproj
@@ -15,6 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Bindings\Constructors\PingResponse.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Bindings\Constructors\Response.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/MelonJs.JavaScript/Models/Web/MelonPingReply.cs
+++ b/MelonJs.JavaScript/Models/Web/MelonPingReply.cs
@@ -4,11 +4,21 @@
     {
         public MelonPingReply(List<float> results)
         {
-            MaxLatency = results.Max();
-            MinLatency = results.Min();
-            AverageLatency = results.Average();
+            if(results != null)
+            {
+                MaxLatency = results.Max();
+                MinLatency = results.Min();
+                AverageLatency = results.Average();
 
-            Results = results;
+                Results = results;
+                return;
+            }
+
+            MaxLatency = 0;
+            MinLatency = 0;
+            AverageLatency = 0;
+
+            Results = new();
         }
 
         public List<float> Results { get; set; }

--- a/MelonJs.JavaScript/Models/Web/MelonPingReply.cs
+++ b/MelonJs.JavaScript/Models/Web/MelonPingReply.cs
@@ -1,0 +1,19 @@
+﻿namespace MelonJs.JavaScript.Models.Web
+{
+    public class MelonPingReply
+    {
+        public MelonPingReply(List<float> results)
+        {
+            MaxLatency = results.Max();
+            MinLatency = results.Min();
+            AverageLatency = results.Average();
+
+            Results = results;
+        }
+
+        public List<float> Results { get; set; }
+        public float AverageLatency { get; set; }
+        public float MaxLatency { get; set; }
+        public float MinLatency { get; set; }
+    }
+}

--- a/MelonJs.JavaScript/Tools/Web/MelonHttp.cs
+++ b/MelonJs.JavaScript/Tools/Web/MelonHttp.cs
@@ -73,6 +73,8 @@ namespace MelonJs.JavaScript.Tools.Web
 
                 try
                 {
+                    target = target.Replace("http://", "").Replace("https://", "");
+
                     PingReply reply = ping.Send(target);
                     results.Add(reply.RoundtripTime);
                 }
@@ -80,6 +82,8 @@ namespace MelonJs.JavaScript.Tools.Web
                 {
                     ping.Dispose();
                 }
+
+                times--;
             }
 
             return new(results);

--- a/MelonJs.JavaScript/Tools/Web/MelonHttp.cs
+++ b/MelonJs.JavaScript/Tools/Web/MelonHttp.cs
@@ -1,6 +1,7 @@
 ﻿using MelonJs.JavaScript.Models.Web;
 using System.Diagnostics;
 using System.Net.Http.Headers;
+using System.Net.NetworkInformation;
 using System.Text.Json;
 
 namespace MelonJs.JavaScript.Tools.Web
@@ -60,6 +61,28 @@ namespace MelonJs.JavaScript.Tools.Web
                 Ok = result.IsSuccessStatusCode,
                 StatusCode = (uint)result.StatusCode
             };
+        }
+
+        public static MelonPingReply Ping(string target, uint times)
+        {
+            List<float> results = new();
+
+            while (times > 0)
+            {
+                Ping ping = new();
+
+                try
+                {
+                    PingReply reply = ping.Send(target);
+                    results.Add(reply.RoundtripTime);
+                }
+                finally
+                {
+                    ping.Dispose();
+                }
+            }
+
+            return new(results);
         }
     }
 }


### PR DESCRIPTION
## Major changes

- Finished `http.ping` method that uses internal `MelonHttp.Ping` function. Usability: `http.ping(targetUrl, repeatTimes? = 1)`.
- Implemented `PingResponse` constructor (max, min, average, results).
- Fixed null gaps in `http.request` and `http.ping` responses.